### PR TITLE
Fix transparency bugs in mt 5.9+

### DIFF
--- a/misc.lua
+++ b/misc.lua
@@ -157,6 +157,7 @@ if depends.homedecor_exterior then
 			}
 		},
 		paramtype = "light",
+		use_texture_alpha = "clip",
 		light_source = 8,
 		is_ground_content = false,
 		groups = {snappy = 3},
@@ -182,6 +183,7 @@ if depends.homedecor_exterior then
 			"homedecor_shrubbery_roots.png"
 		},
 		paramtype = "light",
+		use_texture_alpha = "clip",
 		light_source = 8,
 		is_ground_content = false,
 		groups = {snappy = 3},

--- a/mod.conf
+++ b/mod.conf
@@ -1,3 +1,4 @@
 name = christmas_decor
 description = Christmas-themed decor.
 optional_depends = 3d_armor, basic_materials, bucket, default, dye, farming, homedecor_exterior, mobs, mobs_animal, stairs, vessels, wool, xpanes
+min_minetest_version = 5.4.0


### PR DESCRIPTION
Why? Read https://github.com/Archtec-io/bugtracker/issues/137

- Fix transparency of shrubbery nodes in mt 5.9+
- Add min_minetest_version (v5.4.0 is required since you merged https://github.com/GreenXenith/christmas_decor/pull/2)